### PR TITLE
Don't show create new major body button when not in Editor mode

### DIFF
--- a/src/simulation/ui/system_panel.rs
+++ b/src/simulation/ui/system_panel.rs
@@ -155,7 +155,7 @@ pub fn system_panel(
                                 system_panel_set.commands.run_system(system_panel_set.systems.0[EditorSystemType::CREATE_BODY]);
                             }
                         }
-                        if ui.button("+").on_hover_text("Create new major body").clicked() {
+                        if *system_panel_set.sim_state_type == SimStateType::Editor && ui.button("+").on_hover_text("Create new major body").clicked() {
                             *system_panel_set.create_body_state = CreateBodyState {
                                 parent: None,
                                 body_type: CreateBodyType::Star,


### PR DESCRIPTION
## What kind of change does this PR introduce?
One possible way to fix https://github.com/jan-tennert/SolarSim/issues/4

## What is the current behavior?

The create new major body button appears when the simulation is not in edit mode.


## What is the new behavior?

The create new major body button does not appear when the simulation is not in edit mode.
