### PR TITLE
Minimum zoom autoadjusts based on body diameter.

### DIFF
--- a/src/simulation/components/min_zoom.rs
+++ b/src/simulation/components/min_zoom.rs
@@ -1,0 +1,36 @@
+use bevy::prelude::{in_state, App, Camera, Entity, IntoSystemConfigs, Plugin, PreUpdate, Query, Res, Without};
+use crate::simulation::components::body::BodyChildren;
+use crate::simulation::components::body::BodyShape;
+use crate::simulation::components::body::Mass;
+
+use crate::simulation::components::selection::SelectedEntity;
+use crate::simulation::SimState;
+
+use bevy_panorbit_camera::PanOrbitCamera;
+
+
+pub struct MinZoomPlugin;
+
+impl Plugin for MinZoomPlugin {
+    
+    fn build(&self, app: &mut App) {
+        app
+        .add_systems(PreUpdate, (min_zoom).run_if(in_state(SimState::Loaded)));
+    }
+    
+}
+
+fn min_zoom(
+    query: Query<(Entity, &BodyShape), Without<Camera>>,
+    mut camera_query: Query<(&Camera, &mut PanOrbitCamera), (Without<Mass>, Without<BodyChildren>)>,
+    selected_entity: Res<SelectedEntity>,
+) {
+    if let Some(s_entity) = selected_entity.entity {
+        if let Ok((_, body_shape)) = query.get(s_entity) { // Attempt to fetch BodyShape for selected entity
+            let (_,  mut pan_orbit) = camera_query.single_mut();
+            
+            pan_orbit.zoom_lower_limit = (body_shape.ellipsoid.polar_radius_km/10000.0) as f32;
+        }
+    }
+}
+

--- a/src/simulation/components/mod.rs
+++ b/src/simulation/components/mod.rs
@@ -4,6 +4,7 @@ use crate::simulation::components::billboard::BodyBillboardPlugin;
 use crate::simulation::components::direction::DirectionPlugin;
 use crate::simulation::components::horizons::HorizonsPlugin;
 use crate::simulation::components::lock_on::LockOnPlugin;
+use crate::simulation::components::min_zoom::MinZoomPlugin;
 use crate::simulation::components::motion_line::MotionLinePlugin;
 use crate::simulation::components::reset::ResetPlugin;
 use crate::simulation::components::rotation::RotationPlugin;
@@ -30,6 +31,7 @@ pub mod editor;
 pub mod horizons;
 pub mod scale;
 pub mod anise;
+pub mod min_zoom;
 mod spacecraft;
 
 pub struct SimComponentPlugin;
@@ -45,6 +47,7 @@ impl Plugin for SimComponentPlugin {
             .add_plugins(DirectionPlugin)
             .add_plugins(IntegrationPlugin)
             .add_plugins(LockOnPlugin)
+            .add_plugins(MinZoomPlugin)
             .add_plugins(ScalePlugin)
             .add_plugins(MotionLinePlugin)
             .add_plugins(ResetPlugin)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: `lower_zoom_limit`is now automatically adjusted proportionally to the diameter of the selected body.

## What is the current behavior?
(maximally zoomed in)
![image](https://github.com/user-attachments/assets/b1f56994-f4b8-4565-8892-ea0b2c03cc4e)
![Screenshot from 2025-03-09 04-08-35](https://github.com/user-attachments/assets/fc27f4e4-494a-4b39-a6d3-d16ed28c1e21)


## What is the new behavior?

(maximally zoomed in)
![Screenshot from 2025-03-09 04-02-44](https://github.com/user-attachments/assets/e5627f78-3c8b-429d-a79c-c85d673198ce)
![Screenshot from 2025-03-09 04-01-31](https://github.com/user-attachments/assets/02aadeab-ffd7-4591-9b2e-f413b3df3b53)

## Notes

Worth checking my work here, but it seems to work for all the bodies I tried it with. It was cool to discover how pretty and detailed the 3d models of the ISS and other artificial objects already included with SolarSim are, when as far as I can tell there was no way to zoom in enough to see them previously.